### PR TITLE
docs: adiciona templates e notas de manutencao do repositorio

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Registrar defeito ou comportamento incorreto
+title: "correcao: "
+labels: ["bug"]
+assignees: []
+---
+
+## Problema
+
+Descreva o erro observado.
+
+## Comportamento esperado
+
+Descreva o comportamento esperado.
+
+## Passos para reproduzir
+
+1. 
+2. 
+3. 
+
+## Evidencias
+
+- Logs/stack trace:
+- Prints/screenshot:
+
+## Contexto
+
+- Ambiente (Python/OS):
+- Branch/commit (se souber):
+
+## Criterio de aceite
+
+- [ ] Erro reproduzido
+- [ ] Correcao implementada
+- [ ] Validado apos correcao

--- a/.github/ISSUE_TEMPLATE/documentacao.md
+++ b/.github/ISSUE_TEMPLATE/documentacao.md
@@ -1,0 +1,27 @@
+---
+name: Documentacao
+about: Melhorias em README, guias e instrucoes
+title: "docs: "
+labels: ["documentation"]
+assignees: []
+---
+
+## O que precisa documentar
+
+Descreva o conteudo que esta faltando ou precisa de ajuste.
+
+## Onde atualizar
+
+- [ ] README.md
+- [ ] docs/
+- [ ] Outro:
+
+## Objetivo da documentacao
+
+Ex.: onboarding, uso do CLI, troubleshooting, contribuicao.
+
+## Criterios de aceite
+
+- [ ] Conteudo atualizado
+- [ ] Passos/comandos conferidos
+- [ ] Links internos funcionando

--- a/.github/ISSUE_TEMPLATE/tarefa_tecnica.md
+++ b/.github/ISSUE_TEMPLATE/tarefa_tecnica.md
@@ -1,0 +1,31 @@
+---
+name: Tarefa tecnica
+about: Melhoria tecnica, infra, refatoracao ou manutencao
+title: "tarefa: "
+labels: ["enhancement"]
+assignees: []
+---
+
+## Objetivo
+
+Descreva o resultado esperado da tarefa.
+
+## Motivacao
+
+Por que essa tarefa e necessaria agora?
+
+## Escopo
+
+- Inclui:
+- Nao inclui:
+
+## Criterios de aceite
+
+- [ ] 
+- [ ] 
+
+## Referencias
+
+- Issues:
+- PRs:
+- Arquivos:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Resumo
+
+Descreva em poucas linhas o objetivo deste PR.
+
+## Mudancas principais
+
+- 
+- 
+
+## Como testar
+
+1. 
+2. 
+
+## Issues relacionadas
+
+- Relaciona: #
+- Fecha: # (se aplicavel)
+
+## Checklist
+
+- [ ] Mudanca revisada localmente
+- [ ] README/docs atualizados (se necessario)
+- [ ] Testes adicionados/ajustados (se necessario)
+- [ ] Sem mudancas fora do escopo

--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ poetry run glassdoorcrawler --pages 1
 
 - O HTML do Glassdoor muda com frequencia; ajustes no parsing podem ser necessarios.
 - O crawler usa atraso entre requisicoes (`--delay`) para reduzir bloqueios.
+
+## Manutencao
+
+- Regras do repositorio e ordem sugerida de backlog: `docs/manutencao-regras-e-backlog.md`
+- Registro de decisao do ruleset da branch `master`: `docs/decisao-ruleset-master.md`

--- a/docs/decisao-ruleset-master.md
+++ b/docs/decisao-ruleset-master.md
@@ -1,0 +1,38 @@
+# Registro de Decisao
+
+Data: 2026-02-22
+
+## Decisao
+
+Criar e ativar um ruleset para a branch padrao (`master`) exigindo PR para merge, bloqueando exclusao da branch e force-push.
+
+Tambem foi habilitada a exigencia de resolucao de conversas de review antes do merge.
+
+## Motivo
+
+O repositorio nao tinha ruleset nem protecao de branch. Como o projeto passou a usar issues/PRs para organizar a revisao, a `master` precisava de protecoes minimas para evitar push direto acidental e merges sem revisao explicita.
+
+## Impacto
+
+- Merge na `master` passa a exigir PR
+- Nao e possivel fazer force-push na `master`
+- Nao e possivel excluir a `master`
+- Conversas de review abertas precisam ser resolvidas antes do merge
+- Ainda nao ha status checks obrigatorios (CI nao configurado)
+- Ainda nao ha approvals obrigatorios (mantido fluxo leve)
+- Sem bypass configurado no ruleset (owner tambem segue as regras)
+
+## Revisar em
+
+Revisar apos configurar CI/testes automatizados (issues `#1` e `#2`) para avaliar:
+
+- exigir status checks
+- exigir 1 approval
+- permitir bypass administrativo (se necessario)
+
+## Referencias
+
+- Ruleset: `Protect default branch (PR + conversation resolution)`
+- `docs/manutencao-regras-e-backlog.md`
+- Issue `#8`
+- PR `#7`

--- a/docs/manutencao-regras-e-backlog.md
+++ b/docs/manutencao-regras-e-backlog.md
@@ -1,0 +1,58 @@
+# Manutencao: Ruleset e Proximos Passos
+
+Atualizado em: 2026-02-22
+
+## Ruleset atual (branch padrao `master`)
+
+Ruleset ativo: `Protect default branch (PR + conversation resolution)`
+
+Regras aplicadas:
+
+- Bloqueia exclusao da branch (`deletion`)
+- Bloqueia force-push (`non_fast_forward`)
+- Exige PR para merge (`pull_request`)
+- Exige resolucao de conversas de review antes do merge
+- Nao exige approvals (por enquanto)
+- Nao exige status checks (por enquanto, sem CI)
+
+Observacao:
+
+- Sem bypass configurado (ate o owner precisa seguir PR + resolucao de conversas)
+
+## Quando revisar esse ruleset
+
+Rever quando:
+
+- Adicionar CI/testes automatizados
+- Comecar a receber contribuicoes externas
+- Precisar acelerar hotfix (avaliar bypass admin)
+
+## Proximas issues (ordem sugerida)
+
+1. `#8` validar parametros do CLI (`--pages` e `--delay`)
+2. `#1` validar execucao real do crawler (1 pagina)
+3. `#2` adicionar testes de parsing e paginacao
+4. `#5` melhorar documentacao (README / limitacoes / contribuicao)
+5. `#3` atualizar dependencias e regenerar `poetry.lock`
+6. `#4` adaptar parser ao HTML atual do Glassdoor
+
+## Ajustes de ruleset (depois que tiver CI)
+
+Quando houver workflow de testes:
+
+1. Exigir status checks obrigatorios (ex.: testes)
+2. Opcional: exigir `1` approval
+3. Opcional: manter/ajustar regra de resolucao de conversas
+
+## Dica de manutencao
+
+Sempre que decidir algo de repositorio (ruleset, fluxo de PR, CI), registrar:
+
+- O que foi decidido
+- Motivo
+- Data
+- Quando revisar novamente
+
+## Registros de decisao
+
+- Ruleset da `master`: `docs/decisao-ruleset-master.md`

--- a/docs/templates/decisao.md
+++ b/docs/templates/decisao.md
@@ -1,0 +1,25 @@
+# Registro de Decisao
+
+Data: YYYY-MM-DD
+
+## Decisao
+
+Descreva a decisao tomada.
+
+## Motivo
+
+Explique por que essa decisao foi tomada.
+
+## Impacto
+
+- O que muda no fluxo/codigo/processo
+- Riscos ou trade-offs
+
+## Revisar em
+
+Data ou condicao para revisar (ex.: "apos adicionar CI", "em 30 dias").
+
+## Referencias
+
+- Issues/PRs relacionadas
+- Arquivos afetados


### PR DESCRIPTION
## Resumo
- adiciona templates de issue (bug, tarefa tecnica, documentacao)
- adiciona template de PR
- registra notas de manutencao do repositorio (ruleset, backlog e decisoes)
- adiciona links no README para os documentos de manutencao

## Como revisar
1. Validar templates em `.github/`
2. Validar docs em `docs/`
3. Confirmar se os links do `README.md` fazem sentido no fluxo do projeto

## Issues relacionadas
- Relaciona: #5

## Observacao
- Esta PR organiza o processo do repositorio/GitHub e nao altera a logica do crawler.