### PR TITLE
chore(release): adicionar base de changelog e processo de release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - question
+      - wontfix
+  categories:
+    - title: Correcoes
+      labels:
+        - bug
+    - title: Melhorias
+      labels:
+        - enhancement
+        - refactor
+    - title: Testes
+      labels:
+        - test
+    - title: Infraestrutura
+      labels:
+        - infra
+    - title: Documentacao
+      labels:
+        - documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+Todas as mudancas relevantes deste projeto devem ser registradas aqui.
+
+Este arquivo segue um formato simples inspirado em "Keep a Changelog" e usa versionamento SemVer.
+Enquanto o projeto estiver em `0.x`, mudancas podem acontecer com mais frequencia.
+
+## [Unreleased]
+
+### Added
+- Placeholder para novas funcionalidades ainda nao lancadas.
+
+### Changed
+- Placeholder para ajustes de comportamento ainda nao lancados.
+
+### Fixed
+- Placeholder para correcoes ainda nao lancadas.
+
+### Removed
+- Placeholder para remocoes ainda nao lancadas.
+
+## Como usar
+
+- Registre mudancas em `Unreleased` durante o desenvolvimento.
+- No release, mova os itens para uma secao versionada (`## [0.1.1] - YYYY-MM-DD`).
+- Crie a tag Git correspondente (`v0.1.1`) e publique o GitHub Release.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ poetry run glassdoorcrawler --pages 1
 
 - Regras do repositorio e ordem sugerida de backlog: `docs/manutencao-regras-e-backlog.md`
 - Registro de decisao do ruleset da branch `master`: `docs/decisao-ruleset-master.md`
+- Processo de release e checklist: `docs/release-process.md`
+- Historico de mudancas por versao: `CHANGELOG.md`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,64 @@
+# Processo de Release
+
+Guia rapido para padronizar tags, changelog e GitHub Releases do `glassdoorcrawler`.
+
+## Convencoes
+
+- Versionamento: SemVer (`MAJOR.MINOR.PATCH`)
+- Tags Git: prefixo `v` (ex.: `v0.1.1`)
+- Fonte da versao do pacote: `pyproject.toml` (`tool.poetry.version`)
+- Changelog manual: `CHANGELOG.md`
+- Release notes do GitHub: geradas com base em PRs/labels (config em `.github/release.yml`)
+
+## Quando criar release
+
+Recomendado apos um conjunto coerente de correcoes/melhorias, com branch `master` estavel.
+
+Antes do primeiro fluxo de release "regular", priorize:
+
+- validacao de execucao real do crawler
+- ajuste do parser ao HTML atual
+- testes automatizados minimos
+- CI no GitHub Actions
+
+## Checklist de pre-release
+
+1. Garantir que a `master` local esta atualizada:
+   - `git switch master`
+   - `git pull --ff-only`
+2. Confirmar PRs relevantes mergeados e sem mudancas locais pendentes:
+   - `git status`
+3. Atualizar `CHANGELOG.md`:
+   - mover itens de `Unreleased` para a nova versao
+   - adicionar data (`YYYY-MM-DD`)
+4. Atualizar a versao em `pyproject.toml`
+5. Validar o projeto localmente (comandos disponiveis no momento)
+6. Commitar a preparacao do release:
+   - `git add CHANGELOG.md pyproject.toml`
+   - `git commit -m "chore(release): prepara vX.Y.Z"`
+
+## Criar tag e publicar
+
+1. Criar tag anotada:
+   - `git tag -a vX.Y.Z -m "release: vX.Y.Z"`
+2. Enviar branch e tag:
+   - `git push origin master`
+   - `git push origin vX.Y.Z`
+3. Criar GitHub Release (com notas geradas):
+   - `gh release create vX.Y.Z --generate-notes`
+
+Opcional (titulo customizado):
+
+- `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
+
+## Checklist de pos-release
+
+1. Confirmar que o release apareceu no GitHub
+2. Validar que as notas estao classificadas corretamente (labels)
+3. Abrir ciclo novo mantendo `CHANGELOG.md` com secao `Unreleased`
+
+## Versoes sugeridas para este projeto (fase atual)
+
+- `PATCH` (`0.1.1`): correcoes pequenas (ex.: CLI, docs, infra sem mudar comportamento principal)
+- `MINOR` (`0.2.0`): ajustes relevantes de parser/fluxo/CLI
+- `MAJOR` (`1.0.0`): somente quando houver comportamento minimamente estavel e validado


### PR DESCRIPTION
## Resumo

Adiciona uma base simples para organizar releases do projeto sem alterar o comportamento do crawler.

## Inclui

- CHANGELOG.md com secao Unreleased
- docs/release-process.md com checklist de release
- .github/release.yml para categorizar release notes automaticas por labels

## Objetivo

Padronizar versionamento, tags e GitHub Releases antes de comecar a publicar releases regulares.

## Observacoes

- Mudanca de processo/documentacao (sem impacto funcional no crawler)
- Nao foi criada issue dedicada por ser organizacao interna de release

Closes #16
