### PR TITLE
docs(release): documentar labels e ciclos de release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,6 @@ Enquanto o projeto estiver em `0.x`, mudancas podem acontecer com mais frequenci
 ## Como usar
 
 - Registre mudancas em `Unreleased` durante o desenvolvimento.
+- Use os labels `release:*` das issues/PRs para ajudar a decidir a versao do proximo release.
 - No release, mova os itens para uma secao versionada (`## [0.1.1] - YYYY-MM-DD`).
 - Crie a tag Git correspondente (`v0.1.1`) e publique o GitHub Release.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ poetry run glassdoorcrawler --pages 1
 - Registro de decisao do ruleset da branch `master`: `docs/decisao-ruleset-master.md`
 - Processo de release e checklist: `docs/release-process.md`
 - Historico de mudancas por versao: `CHANGELOG.md`
+- Classificacao de impacto de release (`release:*`) registrada em issues/PRs para apoiar SemVer

--- a/docs/manutencao-regras-e-backlog.md
+++ b/docs/manutencao-regras-e-backlog.md
@@ -27,14 +27,40 @@ Rever quando:
 - Comecar a receber contribuicoes externas
 - Precisar acelerar hotfix (avaliar bypass admin)
 
+## Status rapido do backlog (2026-02-22)
+
+- `#8` concluida (PR `#14`, issue fechada)
+- `#16` concluida (organizacao inicial de releases; PR `#15`, issue fechada)
+- `#1` em andamento (`In Progress`) com diagnostico registrado (`403 Forbidden` na coleta)
+
 ## Proximas issues (ordem sugerida)
 
-1. `#8` validar parametros do CLI (`--pages` e `--delay`)
-2. `#1` validar execucao real do crawler (1 pagina)
+1. `#1` validar execucao real do crawler (1 pagina)
+2. `#4` adaptar parser ao HTML atual do Glassdoor
 3. `#2` adicionar testes de parsing e paginacao
-4. `#5` melhorar documentacao (README / limitacoes / contribuicao)
+4. `#13` configurar CI no GitHub Actions (pytest + checks basicos)
 5. `#3` atualizar dependencias e regenerar `poetry.lock`
-6. `#4` adaptar parser ao HTML atual do Glassdoor
+6. `#12` adicionar LICENSE e documentos de governanca
+7. `#11` configurar Dependabot
+8. `#10` remover artefato versionado da raiz e ajustar politica de outputs
+9. `#5` melhorar documentacao (README / limitacoes / contribuicao)
+
+## Classificacao de release (SemVer)
+
+As issues agora usam labels `release:*` para indicar impacto de versao:
+
+- `release:none`: docs/infra/processo/testes sem impacto funcional direto
+- `release:patch`: correcoes/ajustes compativeis
+- `release:minor`: mudancas relevantes compativeis
+- `release:major`: mudancas incompativeis/importantes
+
+Referencia detalhada: `docs/release-process.md`
+
+## Separacao pratica para releases (resumo)
+
+- Ciclo A (release funcional do crawler): `#1`, `#4`, `#3` + recomendados `#2`, `#13`
+- Ciclo B (governanca/manutencao): `#12`, `#11`, `#10`, `#5`
+- Concluidas relevantes para historico de release: `#6`, `#8`, `#16`
 
 ## Ajustes de ruleset (depois que tiver CI)
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -9,6 +9,28 @@ Guia rapido para padronizar tags, changelog e GitHub Releases do `glassdoorcrawl
 - Fonte da versao do pacote: `pyproject.toml` (`tool.poetry.version`)
 - Changelog manual: `CHANGELOG.md`
 - Release notes do GitHub: geradas com base em PRs/labels (config em `.github/release.yml`)
+- Labels de impacto de release:
+  - `release:none` (sem impacto funcional direto: docs/infra/processo/testes)
+  - `release:patch` (correcao/ajuste sem mudanca relevante de comportamento)
+  - `release:minor` (nova capacidade ou mudanca compativel relevante)
+  - `release:major` (mudanca incompativel/importante)
+
+## Politica de classificacao (issues e PRs)
+
+Objetivo: facilitar decisao de versao (`PATCH`/`MINOR`/`MAJOR`) olhando backlog e PRs concluidos.
+
+Regras praticas:
+
+- Toda issue relevante para entrega deve ter um label `release:*`
+- PRs devem herdar (ou refletir) o mesmo impacto de release da issue relacionada
+- Itens de docs/infra/processo/teste sem impacto funcional direto usam `release:none`
+- Em caso de duvida, prefira `release:patch` e revise antes da tag
+
+Exemplos no projeto:
+
+- `#1`, `#3`, `#4`, `#8` -> `release:patch`
+- `#6` -> `release:minor`
+- `#2`, `#5`, `#10`, `#11`, `#12`, `#13`, `#16` -> `release:none`
 
 ## Quando criar release
 
@@ -28,6 +50,7 @@ Antes do primeiro fluxo de release "regular", priorize:
    - `git pull --ff-only`
 2. Confirmar PRs relevantes mergeados e sem mudancas locais pendentes:
    - `git status`
+   - revisar labels `release:*` das issues/PRs que entraram no ciclo
 3. Atualizar `CHANGELOG.md`:
    - mover itens de `Unreleased` para a nova versao
    - adicionar data (`YYYY-MM-DD`)
@@ -56,6 +79,68 @@ Opcional (titulo customizado):
 1. Confirmar que o release apareceu no GitHub
 2. Validar que as notas estao classificadas corretamente (labels)
 3. Abrir ciclo novo mantendo `CHANGELOG.md` com secao `Unreleased`
+4. (Opcional) revisar se houve issue/PR sem label `release:*` e corrigir para o proximo ciclo
+
+## Estado atual (2026-02-22)
+
+- Base de release criada e mergeada:
+  - `CHANGELOG.md`
+  - `docs/release-process.md`
+  - `.github/release.yml`
+- Labels `release:*` criados e aplicados nas issues do backlog atual
+- Ainda nao existem tags Git nem GitHub Releases publicados
+
+## Separacao do backlog por release (issues)
+
+### 1) Impacto direto de release (mudanca funcional)
+
+Entram no calculo de versao (`PATCH`/`MINOR`/`MAJOR`):
+
+- `release:patch` (abertas): `#1`, `#3`, `#4`
+- `release:patch` (concluida): `#8`
+- `release:minor` (concluida): `#6`
+- `release:major`: nenhuma issue no momento
+
+### 2) Suporte ao release (nao muda versao, mas melhora qualidade)
+
+Usam `release:none`, mas ajudam a estabilizar/publicar:
+
+- `#2` testes de parsing e paginacao
+- `#13` CI no GitHub Actions
+- `#5` documentacao de limites e fluxo de contribuicao
+
+### 3) Organizacao/infra que pode rodar em paralelo (sem bloquear release funcional)
+
+Tambem `release:none`:
+
+- `#10` limpeza de artefato e politica de outputs
+- `#11` Dependabot
+- `#12` LICENSE + governanca (CONTRIBUTING/SECURITY/CODEOWNERS)
+- `#16` organizacao de release (ja concluida)
+
+## Proposta de separacao por ciclos
+
+### Ciclo A - Estabilizacao do crawler (release funcional)
+
+Objetivo: publicar um release com execucao real validada e parser ajustado.
+
+- Core (impacta release): `#1`, `#4`, `#3`
+- Qualidade minima recomendada antes de publicar: `#2`, `#13`
+- Ja concluido e incluso no historico do ciclo: `#8`
+
+Observacao:
+
+- Como `#6` (estrutura do projeto/CLI) ja foi mergeada e esta classificada como `release:minor`, o primeiro release publicado pode ser tratado como `MINOR` (ex.: `v0.2.0`) se voce quiser refletir essa evolucao acumulada.
+- Alternativa conservadora: publicar `v0.1.0` como baseline e usar os labels apenas para releases seguintes.
+
+### Ciclo B - Governanca e manutencao de release
+
+Objetivo: melhorar operacao/manutencao sem alterar comportamento principal.
+
+- `#12` governanca/licenca
+- `#11` Dependabot
+- `#10` outputs/artefatos
+- `#5` documentacao complementar
 
 ## Versoes sugeridas para este projeto (fase atual)
 


### PR DESCRIPTION
## Resumo

Atualiza a documentacao para refletir a organizacao de releases feita no GitHub (labels `release:*`, classificacao de issues e separacao por ciclos).

## Inclui

- politica de classificacao `release:none|patch|minor|major`
- exemplos com issues atuais do backlog
- separacao por ciclos (Ciclo A funcional / Ciclo B governanca)
- atualizacao do backlog/manutencao e referencias no README/CHANGELOG

## Observacoes

- Mudanca apenas de documentacao/processo
- Complementa a base de releases adicionada anteriormente (PR #15)

Closes #18
