### PR TITLE
fix(ci): corrigir import do pacote no pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -e .
           pip install pytest
 
       - name: Basic checks
@@ -39,4 +40,5 @@ jobs:
           python -m pip check
 
       - name: Run tests
-        run: pytest -q
+        run: python -m pytest -q
+


### PR DESCRIPTION
## Resumo
- instala o pacote local no ambiente do CI com pip install -e .
- executa testes com python -m pytest -q

## Problema resolvido
No GitHub Actions, o pytest falhava na coleta com ModuleNotFoundError: No module named 'glassdoorcrawler'.

## Validação
- python -m unittest discover -s tests -q (local): OK (5 testes)
