### PR TITLE
chore: configurar Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 5
+    labels:
+      - "infra"
+      - "release:none"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 5
+    labels:
+      - "infra"
+      - "release:none"


### PR DESCRIPTION
## Resumo\n- adiciona .github/dependabot.yml\n- habilita updates semanais para dependencias Python (pip)\n- habilita updates semanais para GitHub Actions\n- aplica labels infra e release:none nas PRs do Dependabot\n\nCloses #11