### PR TITLE
docs: adicionar arquivos de governanca do repositorio

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default ownership
+* @lucasromualdo
+
+# Automation and repository policies
+/.github/ @lucasromualdo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contribuindo
+
+Obrigado por contribuir com o `glassdoorcrawler`.
+
+## Fluxo de trabalho
+
+1. Crie uma branch a partir de `master`.
+2. Faça mudancas pequenas e focadas em uma issue.
+3. Abra um Pull Request para `master`.
+4. Resolva todas as conversas de review antes do merge.
+
+Observacao: o repositorio usa regra de protecao na branch padrao, entao mudancas devem entrar via PR.
+
+## Desenvolvimento local
+
+### Setup com pip
+
+```bash
+pip install -r requirements.txt
+python -m pip install pytest
+```
+
+### Setup com poetry
+
+```bash
+poetry install
+```
+
+## Como validar
+
+```bash
+python -m pytest -q
+python main.py --pages 1 --no-proxy --output tmp_validacao_1_pagina.xlsx
+```
+
+## Padroes para issues e PRs
+
+- Vincule a issue correspondente no PR (`Relaciona`/`Fecha`).
+- Use labels de release (`release:none`, `release:patch`, `release:minor`, `release:major`) conforme impacto.
+- Atualize documentacao quando houver mudanca de comportamento, fluxo ou processo.
+
+## Escopo e qualidade
+
+- Evite misturar refatoracao ampla com correcao funcional no mesmo PR.
+- Adicione ou ajuste testes quando alterar parsing, paginacao ou regras de coleta.
+- Mantenha o `CHANGELOG.md` coerente com mudancas relevantes de release.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lucas Romualdo Fernandes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ poetry run glassdoorcrawler --pages 1
 - Processo de release e checklist: `docs/release-process.md`
 - Historico de mudancas por versao: `CHANGELOG.md`
 - Classificacao de impacto de release (`release:*`) registrada em issues/PRs para apoiar SemVer
+
+## Governanca
+
+- Licenca do projeto: `LICENSE`
+- Guia de contribuicao: `CONTRIBUTING.md`
+- Politica de seguranca: `SECURITY.md`
+- Responsaveis por revisao de caminhos: `.github/CODEOWNERS`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Este projeto ainda esta na serie `0.x`.
+Correcao de vulnerabilidades e feita em regime de melhor esforco na branch `master`.
+
+## Reporting a Vulnerability
+
+Nao abra vulnerabilidades em issue publica.
+
+Use o canal privado do GitHub Security Advisory:
+
+- https://github.com/lucasromualdo/glassdoor-jobs-crawler/security/advisories/new
+
+Ao reportar, inclua:
+
+- descricao do problema e impacto;
+- passos para reproducao (PoC minima);
+- versao/commit afetado;
+- sugestao de mitigacao, se houver.
+
+## Response Expectations
+
+- Confirmacao inicial: ate 72 horas.
+- Triagem inicial: ate 14 dias.
+- Correcao e divulgacao coordenada: conforme severidade e risco.


### PR DESCRIPTION
## Resumo
- adiciona LICENSE (MIT)
- adiciona CONTRIBUTING.md com fluxo de branch/PR e validacao local
- adiciona SECURITY.md com politica de reporte de vulnerabilidades
- adiciona .github/CODEOWNERS com ownership padrao
- referencia os arquivos de governanca no README

## Como validar
1. Conferir os novos arquivos na raiz e em .github
2. Verificar secao Governanca no README

Closes #12