### PR TITLE
feat: automação diária para execução de issues e limpeza pós-merge

### DIFF
--- a/.github/workflows/daily-issue-automation.yml
+++ b/.github/workflows/daily-issue-automation.yml
@@ -1,0 +1,121 @@
+name: Daily Issue Automation
+
+on:
+  schedule:
+    # 07:00 America/Sao_Paulo (UTC-3)
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  plan-and-execute:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.select.outputs.should_run }}
+      issue_number: ${{ steps.select.outputs.issue_number }}
+      issue_title: ${{ steps.select.outputs.issue_title }}
+    steps:
+      - name: Select one issue or alert
+        id: select
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const openPrs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              base: 'master',
+              per_page: 100,
+            });
+
+            if (openPrs.length > 0) {
+              const body = [
+                'Existe pelo menos 1 PR aberto para `master`.',
+                'Nenhuma nova issue será executada até aprovação e merge.',
+                '',
+                'PRs pendentes:',
+                ...openPrs.map((pr) => `- #${pr.number} ${pr.title}`),
+              ].join('\n');
+
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: '[Alerta Diário] PR pendente de aprovação/merge',
+                body,
+                labels: ['automation-alert'],
+              }).catch(async () => {
+                core.info('Não foi possível criar issue de alerta (label pode não existir).');
+              });
+
+              core.setOutput('should_run', 'false');
+              return;
+            }
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              sort: 'created',
+              direction: 'asc',
+              per_page: 100,
+            });
+
+            const openIssues = issues.filter((i) => !i.pull_request);
+
+            if (openIssues.length === 0) {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: '[Alerta Diário] Sem issues abertas',
+                body: 'Todas as issues estão fechadas no momento. Nada para executar hoje.',
+                labels: ['automation-alert'],
+              }).catch(async () => {
+                core.info('Não foi possível criar issue de alerta (label pode não existir).');
+              });
+
+              core.setOutput('should_run', 'false');
+              return;
+            }
+
+            const selected = openIssues[0];
+            core.setOutput('issue_number', String(selected.number));
+            core.setOutput('issue_title', selected.title);
+            core.setOutput('should_run', 'true');
+
+      - name: Checkout
+        if: steps.select.outputs.should_run == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Prepare branch payload for selected issue
+        if: steps.select.outputs.should_run == 'true'
+        run: |
+          python scripts/issue_worker.py \
+            --issue-number "${{ steps.select.outputs.issue_number }}" \
+            --issue-title "${{ steps.select.outputs.issue_title }}"
+
+      - name: Create Pull Request
+        if: steps.select.outputs.should_run == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(issue #${{ steps.select.outputs.issue_number }}): execução diária automatizada"
+          branch: "automation/issue-${{ steps.select.outputs.issue_number }}"
+          base: master
+          title: "[Daily] Executa issue #${{ steps.select.outputs.issue_number }}"
+          body: |
+            Execução automática diária da issue #${{ steps.select.outputs.issue_number }}.
+
+            Closes #${{ steps.select.outputs.issue_number }}
+          labels: |
+            automated-issue
+            needs-approval
+          draft: false

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -1,0 +1,68 @@
+name: Post Merge Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: read
+  issues: write
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close linked issue (fallback)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const body = context.payload.pull_request.body || '';
+
+            const match = body.match(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i);
+            if (!match) {
+              core.info('PR sem referência de fechamento automático de issue.');
+              return;
+            }
+
+            const issueNumber = Number(match[1]);
+            const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+
+            if (issue.data.state !== 'closed') {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                state: 'closed',
+              });
+              core.info(`Issue #${issueNumber} fechada no fallback.`);
+            }
+
+      - name: Delete branch if still exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headRef = context.payload.pull_request.head.ref;
+
+            try {
+              await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `heads/${headRef}`,
+              });
+
+              await github.rest.git.deleteRef({
+                owner,
+                repo,
+                ref: `heads/${headRef}`,
+              });
+
+              core.info(`Branch ${headRef} apagada.`);
+            } catch (error) {
+              core.info(`Branch ${headRef} já não existe ou não pode ser apagada: ${error.message}`);
+            }

--- a/docs/automacao-issues-diaria.md
+++ b/docs/automacao-issues-diaria.md
@@ -1,0 +1,34 @@
+# Automação diária de issues (07:00)
+
+Este repositório agora possui uma rotina automática para governar execução de issues com as regras:
+
+1. Roda diariamente às 07:00 (America/Sao_Paulo) para levantamento das issues.
+2. Executa no máximo 1 issue por dia.
+3. Para cada execução, cria branch, commit e PR para `master`.
+4. Se houver PR pendente de aprovação/merge, não executa nova issue e gera alerta.
+5. Se não houver issues abertas, gera alerta.
+6. Depois do merge, verifica fechamento da issue e remove branch remanescente.
+
+## Workflows
+
+- `.github/workflows/daily-issue-automation.yml`
+  - Seleciona 1 issue aberta por dia (ordem de criação).
+  - Bloqueia nova execução se houver PR aberto para `master`.
+  - Cria PR automático com referência `Closes #<issue>`.
+- `.github/workflows/post-merge-cleanup.yml`
+  - Ao merge para `master`, garante fechamento da issue (fallback).
+  - Remove a branch relacionada ao PR caso ainda exista.
+
+## Alertas
+
+Os alertas são publicados como issues com títulos:
+
+- `[Alerta Diário] PR pendente de aprovação/merge`
+- `[Alerta Diário] Sem issues abertas`
+
+Sugestão: criar uma automação de notificação (e-mail/Slack) filtrando a label `automation-alert`.
+
+## Observação importante
+
+O script `scripts/issue_worker.py` gera um artefato simples para representar a execução diária da issue.
+Para implementar resolução real (código/testes), substitua esse script por uma rotina que aplique mudanças do seu domínio.

--- a/scripts/issue_worker.py
+++ b/scripts/issue_worker.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Gera artefato mínimo para execução diária de issue."
+    )
+    parser.add_argument("--issue-number", required=True, type=int)
+    parser.add_argument("--issue-title", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    out_dir = Path("docs/daily-issue-runs")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    file_path = out_dir / f"issue-{args.issue_number}.md"
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    file_path.write_text(
+        "\n".join(
+            [
+                f"# Execução diária da issue #{args.issue_number}",
+                "",
+                f"- Título: {args.issue_title}",
+                f"- Executado em: {timestamp}",
+                "- Status: PR aberto para aprovação",
+                "",
+                "> Substitua este gerador pelo fluxo real de implementação da issue.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Implementar rotina diária às 07:00 (America/Sao_Paulo) que levante issues abertas e execute no máximo uma por dia seguindo a política de só prosseguir quando PR anterior estiver aprovado/mergeado.
- Garantir que cada execução gere uma branch, commit e PR para `master`, e que o repositório receba alertas quando não houver execução possível (PR pendente ou sem issues). 
- Automatizar pós-merge para fechar issues vinculadas (fallback) e apagar branches remanescentes.

### Description
- Adiciona o workflow `/.github/workflows/daily-issue-automation.yml` agendado (`cron: '0 10 * * *'`) que verifica PRs abertos para `master`, cria alertas quando houver PR pendente, seleciona uma issue aberta por dia, executa `scripts/issue_worker.py` e cria um PR automático com `peter-evans/create-pull-request@v6` referenciando `Closes #<issue>`. 
- Adiciona o workflow `/.github/workflows/post-merge-cleanup.yml` que, ao detectar merge para `master`, tenta fechar a issue referenciada no corpo do PR e deleta a branch do PR se ainda existir. 
- Inclui o script `scripts/issue_worker.py` que gera um artefato mínimo em `docs/daily-issue-runs/issue-<n>.md` com timestamp e título para representar a execução diária da issue. 
- Documenta o fluxo e alertas em `docs/automacao-issues-diaria.md` explicando regras, alertas e observações de implementação futura. 

### Testing
- Executado com sucesso o script de exemplo `python3 scripts/issue_worker.py --issue-number 123 --issue-title 'Teste de rotina'`, que criou o artefato esperado localmente. 
- Verificada a presença dos novos arquivos com `git status --short` e a árvore de workflows foi inspecionada; não houve falhas automáticas reportadas durante estas verificações.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccae14ee28832d9d6c716425847a7c)